### PR TITLE
[fix] - possibly fixed border overlay isseue when screen height is sm…

### DIFF
--- a/index.css
+++ b/index.css
@@ -44,8 +44,8 @@ emotion-widget {
     position: relative;
     justify-content: center;    
     align-items: center;
-    height: 50%;
     width: 100%;
+    height: calc(100vh -70px);
 }
 #content-wrapper {
     border: 14px #3f3f3f solid;
@@ -74,4 +74,9 @@ button {
 p {
     font-variant-ligatures: discretionary-ligatures;
     font-variant-numeric: ordinal;
+}
+
+header{
+    height: 70px;
+    margin: 0%;
 }

--- a/index.css
+++ b/index.css
@@ -77,6 +77,12 @@ p {
 }
 
 header{
-    height: 70px;
-    margin: 0%;
+    margin-bottom: 40px;
+    width: 30%;
+}
+
+@media screen and (min-width: 300px) {
+    header {
+        width: 100%;
+    }
 }


### PR DESCRIPTION
May have fixed the issue where the header and the content wrapper div overlapped with eachother, specifically when the height of the display was lowered. This was done by setting a height for the header, and changing the height of the content wrapper to depend on specific vh units (the previous height:50% value may have been what was causing the issue). Further testing might be required.

Closes #21 